### PR TITLE
Added broadcast and addr-reuse support, changed the ProtVer 

### DIFF
--- a/src/ofxArtnetProtocol.cpp
+++ b/src/ofxArtnetProtocol.cpp
@@ -38,6 +38,10 @@ void ofxArtnetProtocol::begin()
 void ofxArtnetProtocol::begin(const char* ip)
 {
     bConnected = udpConnection.Create();
+
+		udpConnection.SetEnableBroadcast(true);
+		udpConnection.SetReuseAddress(true);
+
     if (!bConnected) {
         ofLogWarning("ofxArtnetProtocol") << "UDP socket creation failed!!";
         udpConnection.Close();
@@ -136,7 +140,7 @@ void ofxArtnetProtocol::send(uint8_t* data, uint16_t universe, uint16_t size)
     artnet_send_packet[8] = packet.opcode[0];
     artnet_send_packet[9] = packet.opcode[1];
     artnet_send_packet[10] = 0;
-    artnet_send_packet[11] = 0;    // ProtVer (Art-Net Protocol Revision)
+    artnet_send_packet[11] = 14;    // ProtVer (Art-Net Protocol Revision)
     artnet_send_packet[12] = seq;
     artnet_send_packet[13] = 0;                             // physical input port of DMX
     artnet_send_packet[14] = packet.universe[0];


### PR DESCRIPTION
Hi! 

I was trying to get this to work for an installation and the connection was good, the packets were being sent but nothing would happen with the lights, all other controllers were working fine so I was stumped for a few hours. 

I found out that ArtNet controllers are told in the Protocol definition to ignore packets with protocol revision (ProtVer) lower than 14. Once I made the change then everything started working.

Since I was at it, I also activated broadcast support and address reuse on the udpConnection so we can now broadcast artnet as well.

Everything was tested and all the changes work perfectly.

Great work, thanks a lot for the addon, I hope this helps.
Cheers!
  David Jonas